### PR TITLE
Fixed facebook auth

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,7 +9,7 @@ import cookieParser from "cookie-parser";
 const app = express();
 // Configure CORS to allow only requests from port 5173
 const corsOptions = {
-    origin: 'http://localhost:5173',  // Replace with your specific origin
+    origin: 'https://localhost:5173',  // Replace with your specific origin
     credentials : true,
     optionsSuccessStatus: 200,
 };

--- a/backend/app.js
+++ b/backend/app.js
@@ -8,8 +8,9 @@ import cookieParser from "cookie-parser";
 
 const app = express();
 // Configure CORS to allow only requests from port 5173
+// Change URL to https://localhost:5173 if using https
 const corsOptions = {
-    origin: 'https://localhost:5173',  // Replace with your specific origin
+    origin: 'http://localhost:5173',  // Replace with your specific origin
     credentials : true,
     optionsSuccessStatus: 200,
 };

--- a/backend/controllers/auth-controllers.js
+++ b/backend/controllers/auth-controllers.js
@@ -143,28 +143,28 @@ export const getFacebookTokens = async (req, res, next) => {
         const tokens = await axios.get(
             `https://graph.facebook.com/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.FACEBOOK_APP_ID}&client_secret=${process.env.FACEBOOK_APP_SECRET}&fb_exchange_token=${fb_access_token}`
         )
-        .then((res) => {
-            console.log(res);
-            return res.data;
-        })
-        .catch((err) => {
-            console.log(err);
-        })
+        // .then((res) => {
+        //     console.log(res);
+        //     return res.data;
+        // })
+        // .catch((err) => {
+        //     console.log(err);
+        // })
 
-        console.log(tokens);
-        console.log(tokens.access_token);
+        console.log(tokens.data);
+        console.log(tokens.data.access_token);
 
         const des = {
-            fb_user_id : fb_user_id,
-            fb_access_token : fb_access_token,
-            fb_long_access_token : tokens.access_token
+            facebook_user_id : fb_user_id,
+            facebook_access_token : fb_access_token,
+            facebook_long_access_token : tokens.data.access_token
         }
 
         console.log(des);
 
         updateTokensInDestination(user._id.valueOf(), des);
 
-        res.status(200).json(tokens);
+        res.status(200).json(tokens.data);
 
     } catch (error) {
         return res.status(404).json({ message: "error", cause: error.message });

--- a/backend/controllers/auth-controllers.js
+++ b/backend/controllers/auth-controllers.js
@@ -143,19 +143,28 @@ export const getFacebookTokens = async (req, res, next) => {
         const tokens = await axios.get(
             `https://graph.facebook.com/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.FACEBOOK_APP_ID}&client_secret=${process.env.FACEBOOK_APP_SECRET}&fb_exchange_token=${fb_access_token}`
         )
+        .then((res) => {
+            console.log(res);
+            return res.data;
+        })
+        .catch((err) => {
+            console.log(err);
+        })
 
-        console.log(tokens.data);
-        console.log(tokens.data.access_token);
+        console.log(tokens);
+        console.log(tokens.access_token);
 
         const des = {
             fb_user_id : fb_user_id,
             fb_access_token : fb_access_token,
-            fb_long_access_token : tokens.data.access_token
+            fb_long_access_token : tokens.access_token
         }
+
+        console.log(des);
 
         updateTokensInDestination(user._id.valueOf(), des);
 
-        res.status(200).json(tokens.data);
+        res.status(200).json(tokens);
 
     } catch (error) {
         return res.status(404).json({ message: "error", cause: error.message });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 
 export default axios.create({
-    baseURL: "/backend" ,
+    // Change the baseURL to /backend when using proxy and https.
+    // baseURL: "/backend" ,
+    baseURL: "http://localhost:8000/api",
     withCredentials: true,
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
 export default axios.create({
-    baseURL: "http://localhost:8000/api",
+    baseURL: "/backend" ,
     withCredentials: true,
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,17 +10,18 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  server: {
-    https: {
-      key: '/home/sahil/server.key',
-      cert: '/home/sahil/server.crt',
-    },
-    proxy: {
-      '/backend': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/backend/, '/api'),
-      },
-    },
-  },
+  // While adding https remember to change key and cert parameter paths under server -> https to path of your certificate and key.
+  // server: {
+  //   https: {
+  //     key: '/home/sahil/server.key',
+  //     cert: '/home/sahil/server.crt',
+  //   },
+  //   proxy: {
+  //     '/backend': {
+  //       target: 'http://localhost:8000',
+  //       changeOrigin: true,
+  //       rewrite: (path) => path.replace(/^\/backend/, '/api'),
+  //     },
+  //   },
+  // },
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,4 +10,17 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    https: {
+      key: '/home/sahil/server.key',
+      cert: '/home/sahil/server.crt',
+    },
+    proxy: {
+      '/backend': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/backend/, '/api'),
+      },
+    },
+  },
 })


### PR DESCRIPTION
- Added `https` to frontend and added proxy to support plain `http` backend.
- Currently facebook auth can be used with both `https` and `http`.
- Created test app for `StreamSync` on facebook developer account.